### PR TITLE
chore: stop sorting scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -625,7 +625,7 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
       "integrity": "sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==",
       "requires": {
         "@nodelib/fs.stat": "2.0.4",
@@ -634,12 +634,12 @@
     },
     "@nodelib/fs.stat": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
       "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q=="
     },
     "@nodelib/fs.walk": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@nodelib/fs.walk/-/fs.walk-1.2.6.tgz",
       "integrity": "sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==",
       "requires": {
         "@nodelib/fs.scandir": "2.1.4",
@@ -707,7 +707,7 @@
     },
     "@types/glob": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@types/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "requires": {
         "@types/minimatch": "*",
@@ -749,7 +749,7 @@
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
@@ -901,7 +901,7 @@
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
     },
     "array-unique": {
@@ -1480,7 +1480,7 @@
     },
     "detect-indent": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/detect-indent/-/detect-indent-6.0.0.tgz",
       "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
     },
     "detect-newline": {
@@ -1496,7 +1496,7 @@
     },
     "dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "requires": {
         "path-type": "^4.0.0"
@@ -1826,7 +1826,7 @@
     },
     "fast-glob": {
       "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/fast-glob/-/fast-glob-3.2.5.tgz",
       "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1851,7 +1851,7 @@
     },
     "fastq": {
       "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/fastq/-/fastq-1.10.1.tgz",
       "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
       "requires": {
         "reusify": "^1.0.4"
@@ -1989,7 +1989,7 @@
     },
     "git-hooks-list": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
       "integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ=="
     },
     "glob": {
@@ -2007,7 +2007,7 @@
     },
     "glob-parent": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "requires": {
         "is-glob": "^4.0.1"
@@ -2021,7 +2021,7 @@
     },
     "globby": {
       "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/globby/-/globby-10.0.0.tgz",
       "integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
       "requires": {
         "@types/glob": "^7.1.1",
@@ -2185,7 +2185,7 @@
     },
     "ignore": {
       "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
     "import-local": {
@@ -2340,7 +2340,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -2357,7 +2357,7 @@
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "requires": {
         "is-extglob": "^2.1.1"
@@ -2376,7 +2376,7 @@
     },
     "is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
@@ -3315,7 +3315,7 @@
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
@@ -3786,7 +3786,7 @@
     },
     "path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
     },
     "performance-now": {
@@ -3900,7 +3900,7 @@
     },
     "queue-microtask": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/queue-microtask/-/queue-microtask-1.2.2.tgz",
       "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
     },
     "react-is": {
@@ -4097,7 +4097,7 @@
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rimraf": {
@@ -4117,7 +4117,7 @@
     },
     "run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "requires": {
         "queue-microtask": "^1.2.2"
@@ -4504,13 +4504,13 @@
     },
     "sort-object-keys": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
       "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="
     },
     "sort-package-json": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.48.1.tgz",
-      "integrity": "sha512-YvDm1iBzhphfXtctTS0XIBlIW/2N1DZNHx3YMcZnptpZhchqH4zazUOuEWmjfNXndwamITMt9hFPliqwx1SHvQ==",
+      "version": "1.49.0",
+      "resolved": "https://nexus.core.cvent.org/nexus/repository/npm-public/sort-package-json/-/sort-package-json-1.49.0.tgz",
+      "integrity": "sha512-3YuqFGThwc9X0TZLYohOUJJ/P6uJIVcTeuJOc6ZWw4f1fHpTHIfVysKer4qXtrZ2zvwwU2aEcb555Bo+2fwIgQ==",
       "requires": {
         "detect-indent": "^6.0.0",
         "detect-newline": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:unit": "jest"
   },
   "dependencies": {
-    "sort-package-json": "1.48.1"
+    "sort-package-json": "1.49.0"
   },
   "devDependencies": {
     "jest": "26.6.3",


### PR DESCRIPTION
This is a breaking change.

We use npm-run-all for running scripts inside of the package.json.

This treats the order of keys in `scripts` as being meaningful, especially when running sequentially.

Also, we tend to organise our scripts based on the order the scripts are executed in the project lifecycle, which is not always alphabetical.