### PR TITLE
Easier copy-and-paste of the installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ A [Prettier] plugin to sort the keys of a `package.json` file using [sort-packag
 ## Installation
 
 ```bash
-$ npm i -D prettier prettier-plugin-packagejson
+npm i -D prettier prettier-plugin-packagejson
 ```


### PR DESCRIPTION
Codeblocks on Github have a "copy" button now. Pressing was copying the leading `$`. This PR removes it so that one can copy and paste directly into a terminal.